### PR TITLE
add cache to CI and bump checkout version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
+
+      - name: Cache build artifacts #At this point we can cache the build artifacts (checkout would have wiped it out if done earlier)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ github.workspace }}/build
+            ${{ github.workspace }}/.ccache
+          key: build-${{ runner.os }}-${{ github.sha }} #If it's a different commit, content probably changed
+          restore-keys: |
+            build-${{ runner.os }}-
 
       - name: Build with ESP‑IDF
         uses: espressif/esp-idf-ci-action@v1
@@ -17,3 +27,4 @@ jobs:
           esp_idf_version: v6.0
           target: "esp32s3"
           path: "."
+          extra_docker_args: -v ./.ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache


### PR DESCRIPTION
Add some caching to the CI to improve rebuild time. Caching the build directory allow a limited rebuild, but most of the heavy lifting is done via the use of ccache which make the CI build time goes down to 2 minutes on a rebuild instead of more than 7 minutes.

Note: I tested caching the docker pull, and the git pull, but these operation are at best useless, and at worst slower than just doing regular pulls.